### PR TITLE
Initial support for TechEmpower Framework Benchmarks

### DIFF
--- a/perf/README.md
+++ b/perf/README.md
@@ -26,6 +26,7 @@ subdirectory and given a meaningful name.  Once the reorganization of this direc
 //├── dacapo
 //├── renaissance
 //├── liberty
+//├── TechEmpower
 
 ```
 Each subdirectory requires a build.xml file describing where to pull the benchmark suite from, and how to build and run it.  Each subdirectory also requires a playlist.xml file which describes 1 or more benchmarks and what commands to run in order to execute a particular benchmark run.
@@ -48,5 +49,8 @@ Liberty benchmarks from https://github.com/OpenLiberty - including liberty-dt7-s
 
 #### renaissance
 Renaissance benchmarks from https://github.com/renaissance-benchmarks/renaissance - including renaissance-akka-uct, renaissance-als, renaissance-chi-square, renaissance-db-shootout, renaissance-dec-tree, renaissance-finagle-chirper, renaissance-finagle-http, renaissance-fj-kmeans, renaissance-future-genetic, renaissance-gauss-mix, renaissance-log-regression, renaissance-mnemonics, renaissance-movie-lens, renaissance-naive-bayes, renaissance-par-mnemonics, renaissance-philosophers and renaissance-scala-kmeans
+
+#### TechEmpower Framework Benchmarks (TFB)
+Framework Benchmarks from https://github.com/TechEmpower/FrameworkBenchmarks, including tfb-spring, tfb-spring-verify, tfb-jetty, and tfb-jetty-verify. 
 
 Additional benchmarks are being reviewed for addition and if you wish to include more, please comment in the open performance benchmarks [issue 1112](https://github.com/adoptium/aqa-tests/issues/1112).

--- a/perf/TechEmpower/README.md
+++ b/perf/TechEmpower/README.md
@@ -1,0 +1,23 @@
+
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+[1]https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+-->
+
+# TechEmpower Framework Benchmarks (TFB)
+
+The TechEmpower Framework Benchmarks is an [open source](https://github.com/TechEmpower/FrameworkBenchmarks) performance comparison of many web application frameworks executing tasks such as JSON serialization, database access, and server-side template composition. AQA performance testing currently only supports the [spring](https://github.com/TechEmpower/FrameworkBenchmarks/tree/master/frameworks/Java/spring) and [jetty](https://github.com/TechEmpower/FrameworkBenchmarks/tree/master/frameworks/Java/jetty) benchmarks, but other benchmarks may be added in the future.
+
+## Running TechEmpower
+
+The current implementation in the AQA test framework assumes that Docker is installed on the test machine and the Docker daemon is running before TFB tests are run. 
+
+A subsequent PR will add the ability to configure the number of CPUs and memory given to the test container.

--- a/perf/TechEmpower/build.xml
+++ b/perf/TechEmpower/build.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+<project name="TechEmpower" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>TechEmpower</description>
+
+	<!-- set global properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/perf/TechEmpower" />
+	<property name="SRC" location="." />
+
+	<target name="init">
+		<mkdir dir="${DEST}" />
+	</target>
+
+	<target name="getTFB" depends="init" description="Clone the distribution">
+		<var name="DIR_NAME" value="FrameworkBenchmarks"/>
+		<if>
+			<available file="${DIR_NAME}" type="dir" />
+			<then>
+				<echo message="${DIR_NAME} exists. Hence, not cloning it." />
+			</then>
+			<else>
+				<echo message="Cloning TechEmpower Framework Benchmarks"/>
+				<var name="git_command" value="clone --depth 1 -b master https://github.com/TechEmpower/FrameworkBenchmarks.git"/>
+				<echo message="git ${git_command}" />
+				<exec executable="git" failonerror="false" dir=".">
+					<arg line="${git_command}" />
+				</exec>
+			</else>
+		</if>
+	</target>
+
+	<target name="dist" depends="getTFB" description="Generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${SRC}"/>
+		</copy>
+	</target>
+	
+	<target name="build">
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/perf/TechEmpower/playlist.xml
+++ b/perf/TechEmpower/playlist.xml
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+<playlist
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+	<include>../perf.mk</include>
+	<test>
+		<testCaseName>tfb-spring-verify</testCaseName>
+		<command>bash $(Q)$(TEST_RESROOT)$(D)FrameworkBenchmarks/tfb$(Q) --mode verify --test spring; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>tfb-spring</testCaseName>
+		<command>bash $(Q)$(TEST_RESROOT)$(D)FrameworkBenchmarks/tfb$(Q) --test spring; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>tfb-jetty-verify</testCaseName>
+		<command>bash $(Q)$(TEST_RESROOT)$(D)FrameworkBenchmarks/tfb$(Q) --mode verify --test jetty; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>tfb-jetty</testCaseName>
+		<command>bash $(Q)$(TEST_RESROOT)$(D)FrameworkBenchmarks/tfb$(Q) --test jetty; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+</playlist>
+


### PR DESCRIPTION
Add initial support for TechEmpower spring and jetty benchmarks. Currently assumes that Docker is installed and the Docker daemon is running before tests are run.