### PR TITLE
Add EXTRA_YCSB_PROPERTIES

### DIFF
--- a/perf/ycsb/playlist.xml
+++ b/perf/ycsb/playlist.xml
@@ -18,7 +18,7 @@
 	<include>./testenv.mk</include>
 	<test>
 		<testCaseName>ycsb-azurecosmos-load</testCaseName>
-		<command>export JAVA_OPTS=$(JVM_OPTIONS); bash $(Q)$(TEST_RESROOT)$(D)ycsb-$(YCSB_VERSION)/bin/ycsb.sh$(Q) load azurecosmos -P $(Q)$(TEST_RESROOT)$(D)ycsb-$(YCSB_VERSION)/workloads/$(YCSB_WORKLOAD)$(Q) -P $(Q)$(TEST_RESROOT)$(D)azurecosmos.properties$(Q) -s > $(Q)$(REPORTDIR)$(D)load.dat$(Q); \
+		<command>export JAVA_OPTS=$(JVM_OPTIONS); bash $(Q)$(TEST_RESROOT)$(D)ycsb-$(YCSB_VERSION)/bin/ycsb.sh$(Q) load azurecosmos -P $(Q)$(TEST_RESROOT)$(D)ycsb-$(YCSB_VERSION)/workloads/$(YCSB_WORKLOAD)$(Q) -P $(Q)$(TEST_RESROOT)$(D)azurecosmos.properties$(Q) $(EXTRA_YCSB_PROPERTIES) -s > $(Q)$(REPORTDIR)$(D)load.dat$(Q); \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -29,7 +29,7 @@
 	</test>
 	<test>
 		<testCaseName>ycsb-azurecosmos-sanity</testCaseName>
-		<command>export JAVA_OPTS=$(JVM_OPTIONS); bash $(Q)$(TEST_RESROOT)$(D)ycsb-$(YCSB_VERSION)/bin/ycsb.sh$(Q) run azurecosmos -P $(Q)$(TEST_RESROOT)$(D)ycsb-$(YCSB_VERSION)/workloads/$(YCSB_WORKLOAD)$(Q) -P $(Q)$(TEST_RESROOT)$(D)azurecosmos.properties$(Q) -p operationcount=100 -s > $(Q)$(REPORTDIR)$(D)transactions.dat$(Q); \
+		<command>export JAVA_OPTS=$(JVM_OPTIONS); bash $(Q)$(TEST_RESROOT)$(D)ycsb-$(YCSB_VERSION)/bin/ycsb.sh$(Q) run azurecosmos -P $(Q)$(TEST_RESROOT)$(D)ycsb-$(YCSB_VERSION)/workloads/$(YCSB_WORKLOAD)$(Q) -P $(Q)$(TEST_RESROOT)$(D)azurecosmos.properties$(Q) -p operationcount=100 $(EXTRA_YCSB_PROPERTIES) -s > $(Q)$(REPORTDIR)$(D)transactions.dat$(Q); \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -40,7 +40,7 @@
 	</test>
 	<test>
 		<testCaseName>ycsb-azurecosmos</testCaseName>
-		<command>export JAVA_OPTS=$(JVM_OPTIONS); bash $(Q)$(TEST_RESROOT)$(D)ycsb-$(YCSB_VERSION)/bin/ycsb.sh$(Q) run azurecosmos -P $(Q)$(TEST_RESROOT)$(D)ycsb-$(YCSB_VERSION)/workloads/$(YCSB_WORKLOAD)$(Q) -P $(Q)$(TEST_RESROOT)$(D)azurecosmos.properties$(Q) -s > $(Q)$(REPORTDIR)$(D)transactions.dat$(Q); \
+		<command>export JAVA_OPTS=$(JVM_OPTIONS); bash $(Q)$(TEST_RESROOT)$(D)ycsb-$(YCSB_VERSION)/bin/ycsb.sh$(Q) run azurecosmos -P $(Q)$(TEST_RESROOT)$(D)ycsb-$(YCSB_VERSION)/workloads/$(YCSB_WORKLOAD)$(Q) -P $(Q)$(TEST_RESROOT)$(D)azurecosmos.properties$(Q) $(EXTRA_YCSB_PROPERTIES) -s > $(Q)$(REPORTDIR)$(D)transactions.dat$(Q); \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
Add the ability for extra [YCSB properties](https://github.com/brianfrankcooper/YCSB/wiki/Core-Properties) (e.g. `-p recordcount=10000 -p operationcount=10000`) to be passed in via an environment variable EXTRA_YCSB_PROPERTIES