### PR TITLE
Moving disable_smt after set_cpu_performance

### DIFF
--- a/perf/benchmark_setup_linux.sh
+++ b/perf/benchmark_setup_linux.sh
@@ -200,9 +200,9 @@ function parse_arguments() {
 # Run all functions
 function run_all() {
     check_numa
-    disable_smt
     set_cpu_performance
     disable_turbo
+    disable_smt
     sync_disks
     clear_cache
     set_thp_madvise

--- a/perf/benchmark_setup_linux.sh
+++ b/perf/benchmark_setup_linux.sh
@@ -201,8 +201,8 @@ function parse_arguments() {
 function run_all() {
     check_numa
     set_cpu_performance
-    disable_turbo
     disable_smt
+    disable_turbo
     sync_disks
     clear_cache
     set_thp_madvise


### PR DESCRIPTION
Currently, when we call disable_smt before calling set_cpu_performance, the latter fails when trying to set the CPU to performance for CPUs that were just disabled by disable_smt.

This PR moves disable_smt *after* set_cpu_performance in order to avoid these failures.